### PR TITLE
Remove 'fs' and 'path' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,5 @@
     "url": "https://github.com/adalbertoteixeira/jest-bamboo-formatter"
   },
   "dependencies": {
-    "fs": "0.0.2",
-    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Ref: http://npm.im/fs

Both `fs` and `path` are Node.js native, so you probably don't want the code from npm.