### PR TITLE
Throw an error whenever a parse error is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = function reporter(results) {
   output.stats.end = new Date();
 
   results.testResults.forEach(function suiteIterator(suiteResult) {
+    if (suiteResult.testExecError) {
+      throw new Error(suiteResult.testExecError.message);
+    }
+
     suiteResult.testResults.forEach(function testIterator(testResult) {
       /* istanbul ignore else */
       if (testResult.status === 'passed') {


### PR DESCRIPTION
**Bug**
Currently, if a parse error exists in a test module, the formatter will not report the error and skip the tests suite result and stay silent. 

**Fix**
Throws a process error whenever an execution error is thrown.